### PR TITLE
fix titleFlex param in title

### DIFF
--- a/lib/src/pages/cupertino_onboarding_page.dart
+++ b/lib/src/pages/cupertino_onboarding_page.dart
@@ -82,7 +82,7 @@ class CupertinoOnboardingPage extends StatelessWidget {
               children: [
                 const Spacer(),
                 Expanded(
-                  flex: 3,
+                  flex: titleFlex,
                   child: title,
                 ),
                 const Spacer(),


### PR DESCRIPTION
Similar to this pull request: https://github.com/ivirtex/cupertino_onboarding/pull/23, but without the version change. I encountered the same issue with the package and reached the same conclusion.