### PR TITLE
Adjusted right padding for onboarding page.

### DIFF
--- a/lib/src/pages/cupertino_onboarding_page.dart
+++ b/lib/src/pages/cupertino_onboarding_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 // Project imports:
 import 'package:cupertino_onboarding/src/constants.dart';
 
-const EdgeInsets _kOnboardingPagePadding = EdgeInsets.only(left: 35, right: 15);
+const EdgeInsets _kOnboardingPagePadding = EdgeInsets.only(left: 35, right: 35);
 
 const double _kTitleTopIndent = 80;
 


### PR DESCRIPTION
This pull request fixes the padding issue in the onboarding page.

Previously:
const EdgeInsets _kOnboardingPagePadding = EdgeInsets.only(left: 35, right: 15);

Issue:
The icon was placed 20 pixels closer to the right side, which was not visually balanced.

Fix:
Changed to:
const EdgeInsets _kOnboardingPagePadding = EdgeInsets.only(left: 35, right: 35);